### PR TITLE
Don't use Option as Meta key

### DIFF
--- a/Snazzy.terminal
+++ b/Snazzy.terminal
@@ -1686,6 +1686,6 @@
 	<key>type</key>
 	<string>Window Settings</string>
 	<key>useOptionAsMetaKey</key>
-	<true/>
+	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
With an azerty keyboard, you can generate the `~` char with `option`+`n`. So if `useOptionAsMetaKey` is set to true, it's not possible to generate the `~` in the terminal.